### PR TITLE
refresh backend when listing devices

### DIFF
--- a/usb_device.py
+++ b/usb_device.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """USB device wrapper module for usbipd."""
 
+import usb.backend.libusb1 as libusb1
 import usb.core
 import usb.util
 
@@ -27,6 +28,9 @@ class USBDevice:
         """
         Find a USB device by its bus ID.
 
+        Uses a fresh libusb backend to ensure devices that went idle
+        are properly re-enumerated.
+
         Args:
             bus_id: The bus ID in format 'bus-port.port...' (e.g., '1-4.3').
 
@@ -47,7 +51,9 @@ class USBDevice:
                 "Expected format: bus-port.port... (e.g., 1-4.3)"
             ) from error
 
-        devices = usb.core.find(find_all=True)
+        # Create a fresh backend to force re-enumeration of USB devices
+        backend = libusb1.get_backend()
+        devices = usb.core.find(find_all=True, backend=backend)
         for device in devices:
             device_port_numbers = device.port_numbers if device.port_numbers else (0,)
             if device.bus == target_bus and device_port_numbers == target_port_numbers:

--- a/usbipd.py
+++ b/usbipd.py
@@ -9,6 +9,7 @@ import argparse
 import logging
 import sys
 
+import usb.backend.libusb1 as libusb1
 import usb.core
 import usb.util
 
@@ -90,10 +91,16 @@ def list_usb_devices() -> list[dict]:
     """
     Find and list all connected USB devices.
 
+    Uses a fresh libusb backend to ensure devices that went idle
+    are properly re-enumerated.
+
     Returns:
         A list of dictionaries containing information about each USB device.
     """
-    devices = usb.core.find(find_all=True)
+    # Create a fresh backend to force re-enumeration of USB devices
+    # This fixes issues where idle devices are not listed
+    backend = libusb1.get_backend()
+    devices = usb.core.find(find_all=True, backend=backend)
     device_list = []
 
     for device in devices:


### PR DESCRIPTION
Refreshes the backend when listing devices, hoping this will allow all devices to be listed instead of sometimes disappearing.